### PR TITLE
Update styles.css

### DIFF
--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -61,16 +61,17 @@
   background-color: rgb(50, 195, 205);
 }
 
+
+.remove {
+  background-color: rgb(235, 103, 80);
+}
+
 .dragactive {
   background-color: rgb(0, 221, 236);
 }
 
 .dragcomplete {
   background-color: rgb(255, 38, 0);
-}
-
-.remove {
-  background-color: rgb(235, 103, 80);
 }
 
 .todos__heading {


### PR DESCRIPTION
.remove was overriding .dragcomplete, so the 'brightening' effect caused by the snapshot.isDraggingOver ternary operator in TodoList.tsx was producing the expected results. Followed along with your FreeCodeCamp video and spotted this. For the record, it is shown correctly in the video.